### PR TITLE
Meeshkanify links

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
     <h2>Jobs</h2>
       <p>We will hire our next batch of Meeshkanites in Q2 2020. In the meantime, if you would like to be part of the adventure, we always welcome free-form applications. <a href="mailto:jobs@meeshkan.com">Send us an email</a>.</p>
     <h2>Open source</h2>
-      <p>We contribute to or lead development in over 100 Open Source projects. Your contributions are welcome. Join our <a href="https://gitter.im/unmock/community">Gitter</a> or check out some of our <a href="https://github.com/unmock">GitHub repos</a> for more information.</p>
+      <p>We contribute to or lead development in over 100 Open Source projects. Your contributions are welcome. Join our <a href="https://gitter.im/meeshkan/community">Gitter</a> or check out some of our <a href="https://github.com/meeshkan">GitHub repos</a> for more information.</p>
     <h3>html revolution</h3>
       <p>This site is part of the HTML revolution network, a movement to make websites more energy efficient by reducing extraneous browser rendering cycles. Join us on <a href="https://html-revolution.org">html-revolution.org</a>.</p>
   </body>


### PR DESCRIPTION
Under the `Open Source` section of the website, the Gitter and GitHub links are still pointing to the Unmock resources. So I updated them to the Meeshkan links.