### PR TITLE
Add in syntax highlighting with the 11ty plugin

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,12 +1,13 @@
-module.exports = function(eleventyConfig) {
-  eleventyConfig.setTemplateFormats([
-    "md",
-    "html",
-    "css",
-    "njk"
-  ]);
+const syntaxHighlightPlugin = require("@11ty/eleventy-plugin-syntaxhighlight");
+
+module.exports = function (eleventyConfig) {
+  eleventyConfig.setTemplateFormats(["md", "html", "css", "njk"]);
 
   eleventyConfig.setDataDeepMerge(true);
 
-  eleventyConfig.addFilter("readableDate", dateObj => dateObj.toLocaleDateString());
+  eleventyConfig.addFilter("readableDate", dateObj =>
+    dateObj.toLocaleDateString()
+  );
+
+  eleventyConfig.addPlugin(syntaxHighlightPlugin);
 };

--- a/_includes/layouts/base.njk
+++ b/_includes/layouts/base.njk
@@ -4,7 +4,13 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <title>{{ renderData.title or title or metadata.title }}</title>
-        <link rel="stylesheet" href="{{ '/css/index.css' | url }}">
+
+        {%- set css %}
+            {% include 'index.css' %}
+            {% include 'prism-theme.css' %}
+        {% endset %}
+
+        <style>{{ css | safe }}</style>
     </head>
     <body>
         <main{% if templateClass %} class="{{ templateClass }}" {% endif %}>

--- a/_includes/prism-theme.css
+++ b/_includes/prism-theme.css
@@ -1,0 +1,120 @@
+/**
+ * Dracula Theme originally by Zeno Rocha [@zenorocha]
+ * https://draculatheme.com/
+ *
+ * Ported for PrismJS by Albert Vallverdu [@byverdu]
+ */
+
+code[class*="language-"],
+pre[class*="language-"] {
+	color: #f8f8f2;
+	text-shadow: 0 1px rgba(0, 0, 0, 0.3);
+	font-family: monospace;
+	text-align: left;
+	white-space: pre;
+	word-spacing: normal;
+	word-break: normal;
+	word-wrap: normal;
+	line-height: 1.5;
+	-moz-tab-size: 4;
+	-o-tab-size: 4;
+	tab-size: 4;
+	-webkit-hyphens: none;
+	-moz-hyphens: none;
+	-ms-hyphens: none;
+	hyphens: none;
+}
+
+/* Code blocks */
+pre[class*="language-"] {
+	padding: 1em;
+	margin: .5em 0;
+	overflow: auto;
+}
+
+:not(pre) > code[class*="language-"],
+pre[class*="language-"] {
+	background: #282a36;
+}
+
+/* Inline code */
+:not(pre) > code[class*="language-"] {
+	padding: .1em;
+	border-radius: .3em;
+	white-space: normal;
+}
+
+.token.comment,
+.token.prolog,
+.token.doctype,
+.token.cdata {
+	color: #6272a4;
+}
+
+.token.punctuation {
+	color: #f8f8f2;
+}
+
+.namespace {
+	opacity: .7;
+}
+
+.token.property,
+.token.tag,
+.token.constant,
+.token.symbol,
+.token.deleted {
+	color: #ff79c6;
+}
+
+.token.boolean,
+.token.number {
+	color: #bd93f9;
+}
+
+.token.selector,
+.token.attr-name,
+.token.string,
+.token.char,
+.token.builtin,
+.token.inserted {
+	color: #50fa7b;
+}
+
+.token.operator,
+.token.entity,
+.token.url,
+.language-css .token.string,
+.style .token.string,
+.token.variable {
+	color: #f8f8f2;
+}
+
+.token.atrule,
+.token.attr-value,
+.token.function,
+.token.class-name {
+	color: #f1fa8c;
+}
+
+.token.keyword {
+	color: #8be9fd;
+}
+
+.token.regex,
+.token.important {
+	color: #ffb86c;
+}
+
+.token.important,
+.token.bold {
+	font-weight: bold;
+}
+
+.token.italic {
+	font-style: italic;
+}
+
+.token.entity {
+	cursor: help;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,15 @@
         "valid-url": "^1.0.9"
       }
     },
+    "@11ty/eleventy-plugin-syntaxhighlight": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@11ty/eleventy-plugin-syntaxhighlight/-/eleventy-plugin-syntaxhighlight-3.0.1.tgz",
+      "integrity": "sha512-+cXc5oyFagCat+JgIh+4cI1otQMVYSsXjxj2/8J78I+p6ICvCfObzvi7PTXvDPbwXOQP8RkcB4DYOP+MKkcPAw==",
+      "dev": true,
+      "requires": {
+        "prismjs": "^1.17.1"
+      }
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
@@ -850,6 +859,18 @@
         }
       }
     },
+    "clipboard": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.6.tgz",
+      "integrity": "sha512-g5zbiixBRk/wyKakSwCKd7vQXDjFnAMGHoEyBogG/bw9kTD9GvdAvaoRR1ALcEzt3pVKxZR0pViekPMIS0QyGg==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "good-listener": "^1.2.2",
+        "select": "^1.1.2",
+        "tiny-emitter": "^2.0.0"
+      }
+    },
     "cliui": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
@@ -1116,6 +1137,13 @@
         "pinkie-promise": "^2.0.0",
         "rimraf": "^2.2.8"
       }
+    },
+    "delegate": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
+      "integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==",
+      "dev": true,
+      "optional": true
     },
     "depd": {
       "version": "1.1.2",
@@ -2356,6 +2384,16 @@
           "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
           "dev": true
         }
+      }
+    },
+    "good-listener": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
+      "integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "delegate": "^3.1.2"
       }
     },
     "graceful-fs": {
@@ -3714,6 +3752,15 @@
         "parse-ms": "^0.1.0"
       }
     },
+    "prismjs": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.19.0.tgz",
+      "integrity": "sha512-IVFtbW9mCWm9eOIaEkNyo2Vl4NnEifis2GQ7/MLRG5TQe6t+4Sj9J5QWI9i3v+SS43uZBlCAOn+zYTVYQcPXJw==",
+      "dev": true,
+      "requires": {
+        "clipboard": "^2.0.0"
+      }
+    },
     "process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -4210,6 +4257,13 @@
           }
         }
       }
+    },
+    "select": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
+      "integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0=",
+      "dev": true,
+      "optional": true
     },
     "semver": {
       "version": "7.1.3",
@@ -4941,6 +4995,13 @@
           "dev": true
         }
       }
+    },
+    "tiny-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
+      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
+      "dev": true,
+      "optional": true
     },
     "to-array": {
       "version": "0.1.4",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "homepage": "https://github.com/meeshkan/worlds-greatest-website/",
   "devDependencies": {
-    "@11ty/eleventy": "^0.10.0"
+    "@11ty/eleventy": "^0.10.0",
+    "@11ty/eleventy-plugin-syntaxhighlight": "^3.0.1"
   }
 }


### PR DESCRIPTION
In reference to issue #13 I've added syntax highlighting to the website, mainly used in the blog. 

For simplicity and _lightness_ I went with the [11ty syntaxhighlight plugin](https://www.11ty.dev/docs/plugins/syntaxhighlight/).

The code theme can be changed in the `prism-theme.css` file. I've defaulted to the Dracula theme for the moment although its a bit out of place with no other CSS on the page 😂.

There is also an overflow property added to code that prevents pages from needing to scroll horizontally which is especially a pain on mobile.

I've also changed the configuration of inserting CSS files in the base layout to use the njk syntax for multiple stylesheets. If this is unwanted, let me know and I can reverse it!